### PR TITLE
Fix DynamicFuzzer category implementation

### DIFF
--- a/IOKitFuzz/BugFuzz/DynamicFuzzer2.m
+++ b/IOKitFuzz/BugFuzz/DynamicFuzzer2.m
@@ -2,12 +2,24 @@
 #import <mach/mach.h>
 #import <IOKit/IOKitLib.h>
 #import <IOSurface/IOSurfaceRef.h>
+#import <objc/runtime.h>
 
-@interface DynamicFuzzer()
+@interface DynamicFuzzer (Fuzzing)
 @property (nonatomic, assign, readwrite) BOOL isFuzzing;
 @end
 
-@implementation DynamicFuzzer
+static const void *kIsFuzzingKey = &kIsFuzzingKey;
+
+@implementation DynamicFuzzer (Fuzzing)
+
+- (void)setIsFuzzing:(BOOL)value {
+    objc_setAssociatedObject(self, kIsFuzzingKey,
+                             @(value), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL)isFuzzing {
+    return [objc_getAssociatedObject(self, kIsFuzzingKey) boolValue];
+}
 
 - (void)startFuzzingWithLogHandler:(void (^)(NSString *logMessage))logHandler {
     if (self.isFuzzing) return;


### PR DESCRIPTION
## Summary
- add Objective-C runtime helpers to implement `isFuzzing` as a category property
- rename category implementation to avoid duplicate class implementation warnings

## Testing
- `clang -fsyntax-only -x objective-c -fobjc-arc IOKitFuzz/BugFuzz/DynamicFuzzer2.m` *(fails: `-fobjc-arc is not supported on platforms using the legacy runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_686e092e117c8322b758f6e7f0fa2e99