### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ DynamicFuzzer *fuzzer = [[DynamicFuzzer alloc] init];
 ```
 
 ## 📖 Credits
-AppinstalleriOS - Thanks for optimizing the code to find exact selector of IOServices
+AppInstaller iOS - Thanks for optimizing the code to find exact selector of IOServices


### PR DESCRIPTION
## Summary
- fix the spelling of **AppInstaller iOS** in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e0afce3e48322a44f63bc6bfecff1